### PR TITLE
First fix of SerializingQuadWriter not getting properly reset

### DIFF
--- a/ldif/ldif-core/src/main/scala/ldif/output/SerializingQuadWriter.scala
+++ b/ldif/ldif-core/src/main/scala/ldif/output/SerializingQuadWriter.scala
@@ -46,6 +46,7 @@ case class SerializingQuadWriter(filepath: String, syntax: RDFSyntax) extends Qu
     if (writer!=null) {
       writer.flush()
       writer.close()
+      writer = null
     }
   }
 }


### PR DESCRIPTION
This is a fix for #5. As we call finish() on a SerializingQuadWriter, we also have to remove the underlying BufferedWriter. Otherwise if we call write again on the QuadWriter it'll try to use a closed BufferedWriter resulting in issue #5.
