### PR TITLE
Added import job which executes a shell script and loads the created dump

### DIFF
--- a/ldif/ldif-core/src/main/resources/xsd/ImportJob.xsd
+++ b/ldif/ldif-core/src/main/resources/xsd/ImportJob.xsd
@@ -34,6 +34,15 @@
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="commandLineImportJob" substitutionGroup="ldif:job">
+    <xs:complexType>
+       <xs:sequence>
+        <xs:element name="dumpLocation" type="xs:string" />
+        <xs:element name="scriptLocation" type="xs:string" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name="tripleImportJob" substitutionGroup="ldif:job">
     <xs:complexType>
        <xs:sequence>

--- a/ldif/ldif-local/src/main/scala/ldif/local/scheduler/CommandLineImportJob.scala
+++ b/ldif/ldif-local/src/main/scala/ldif/local/scheduler/CommandLineImportJob.scala
@@ -1,0 +1,63 @@
+/* 
+ * LDIF
+ *
+ * Copyright 2011-2014 Universität Mannheim, MediaEvent Services GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ldif.local.scheduler
+
+import xml.Node
+import java.io.OutputStream
+import ldif.util._
+import sys.process._
+
+case class CommandLineImportJob(dumpLocation : String, scriptLocation : String, id : Identifier, refreshSchedule : String, dataSource : String) extends DumpImportJob(dumpLocation) {
+
+  val reporter = new CommandLineImportJobPublisher(id)
+
+  override def getType = "command-line-triple"
+
+  override def load(out : OutputStream, estimatedNumberOfQuads : Option[Double] = None) : Boolean = {
+    importedGraphs += graph
+    ("bash " + scriptLocation).! // Execute the script
+    loadDump(out, estimatedNumberOfQuads)
+  }
+
+  def toXML = {
+    val xml = {
+      <tripleImportJob>
+        <dumpLocation>{dumpLocation}</dumpLocation>
+        <scriptLocation>{scriptLocation}</scriptLocation>
+      </tripleImportJob>
+    }
+    toXML(xml)
+  }
+
+  def getReporter = reporter
+}
+
+object CommandLineImportJob {
+
+  def fromXML (node : Node, id : Identifier, refreshSchedule : String, dataSource : String) : ImportJob = {
+    val dumpLocation : String = (node \ "dumpLocation" text)
+    val scriptLocation : String = (node \ "scriptLocation" text)
+    val job = new CommandLineImportJob(dumpLocation.trim, scriptLocation, id, refreshSchedule, dataSource)
+    job
+  }
+}
+
+class CommandLineImportJobPublisher (id : Identifier) extends DumpImportJobPublisher(id) {
+  override def getPublisherName = super.getPublisherName + " (triple)"
+}

--- a/ldif/ldif-local/src/main/scala/ldif/local/scheduler/ImportJob.scala
+++ b/ldif/ldif-local/src/main/scala/ldif/local/scheduler/ImportJob.scala
@@ -145,6 +145,11 @@ object ImportJob {
     val dataSource = (node \ "dataSource" text)
     val refreshSchedule = (node \ "refreshSchedule" text)
 
+    (node \ "commandLineImportJob").headOption match {
+      case Some(job) => return CommandLineImportJob.fromXML(job, id, refreshSchedule, dataSource)
+      case None =>
+    }
+
     (node \ "quadImportJob").headOption match {
       case Some(job) => return QuadImportJob.fromXML(job, id, refreshSchedule, dataSource)
       case None =>


### PR DESCRIPTION
As we worked with the pipeline we run into the situation where we had to import dumps which did not comply with any standard (e.g. IMDb). In order to process these dumps with ldif we needed more flexibility.

Therefore we added this ImportJob which allows us to import arbritrary things into the pipeline. It is simply an ImportJob class which executes a shell script and reads in a triple afterwards. This is just a proposal as it opens the pipeline to any kind of extension.
